### PR TITLE
github: Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Najahiiii @AyraHikari


### PR DESCRIPTION

Used by GitHub to automatically request review from concerned people on PRs.

https://help.github.com/en/articles/about-code-owners